### PR TITLE
feat(docker): upgrade to jdk12, tomcat 9, postgres 12 and nginx 1.23.4

### DIFF
--- a/aio-base/Dockerfile
+++ b/aio-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8 as builder
+FROM adoptopenjdk/openjdk12 as builder
 
 RUN set -ex \
 	&& DEBIAN_FRONTEND=noninteractive apt-get update \
@@ -15,18 +15,18 @@ ENV CATALINA_HOME /usr/local/tomcat
 ENV CATALINA_BASE /var/lib/tomcat
 
 RUN set -ex \
-	&& export TOMCAT_MAJOR="8" \
-	&& export TOMCAT_VERSION="8.5.38" \
-	&& export TOMCAT_ESUM="3a3e624014faf87091e6dbb8bad13c68240955d62301d22cf3d75a1766859dd97500d6850fbd5d3dc012f08f9301eb24c24fa7175bcca616767fa5c18875072d" \
+	&& export TOMCAT_MAJOR="9" \
+	&& export TOMCAT_VERSION="9.0.55" \
+	&& export TOMCAT_ESUM="a0c480b8bba09069bda3b57f54e658450a59d799474ad587dead0ffbf5074c16ee3f9f9c13312d0ff3227c7034589dabf25941fbd672838e9baeee9661e024dc" \
 	&& export TOMCAT_PKG="apache-tomcat-$TOMCAT_VERSION.tar.gz" \
 	&& mkdir -p $CATALINA_HOME \
 	&& mkdir -p $CATALINA_BASE \
 	&& cd $CATALINA_HOME \
-	&& curl -L -O "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/$TOMCAT_PKG" \
+	&& curl -L -O "https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/$TOMCAT_PKG" \
 	&& echo "$TOMCAT_ESUM $TOMCAT_PKG" | sha512sum -c - \
 	&& tar -xvf $TOMCAT_PKG --strip-components=1 \
+	&& rm -f $CATALINA_HOME/bin/*.bat \
 	&& rm -f $TOMCAT_PKG \
-	&& rm -f $TOMCAT_HOME/bin/*.bat \
 	&& chmod 755 $CATALINA_HOME/bin \
 	&& chmod 755 $CATALINA_HOME/lib \
 	&& chmod 755 $CATALINA_HOME/conf \
@@ -69,7 +69,7 @@ RUN set -ex \
 
 ## end of builder stage
 
-FROM adoptopenjdk/openjdk8
+FROM adoptopenjdk/openjdk12
 LABEL maintainer="Axelor <support@axelor.com>"
 
 RUN set -ex \
@@ -84,12 +84,13 @@ RUN set -ex \
 	&& echo 'deb https://deb.nodesource.com/node_8.x bionic main' > /etc/apt/sources.list.d/nodesource.list \
 	&& apt-key adv --batch --fetch-keys https://dl.yarnpkg.com/debian/pubkey.gpg \
 	&& echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list \
+	&& echo 'deb [trusted=yes] http://deb.debian.org/debian/ buster main' >> /etc/apt/sources.list \
 	&& DEBIAN_FRONTEND=noninteractive apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y \
-		supervisor gosu postgresql-9.6 postgresql-contrib-9.6 \
+		supervisor gosu postgresql-12 postgresql-contrib-12 \
 		libapr1 nginx nginx-module-xslt nginx-module-geoip nginx-module-image-filter nginx-module-njs gettext-base \
-		git-core nodejs yarn \
+		git-core nodejs yarn libreadline7 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # update locale
@@ -131,22 +132,23 @@ RUN set -ex \
 	&& chown -R $TOMCAT_USER:$TOMCAT_GROUP /var/log/tomcat
 
 # tomcat-native lib path
-ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$CATALINA_HOME/native-jni-lib
+ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
 # postgres
 ENV POSTGRES_USER axelor
 ENV POSTGRES_PASSWORD axelor
 ENV POSTGRES_DB axelor
 
-ENV PATH $PATH:/usr/lib/postgresql/9.6/bin
-ENV PGDATA /var/lib/postgresql/9.6/main
+ENV PATH $PATH:/usr/lib/postgresql/12/bin
+ENV PGDATA /var/lib/postgresql/12/main
 
 RUN set -ex \
-	&& echo "host all all all md5" >> /etc/postgresql/9.6/main/pg_hba.conf \
-	&& echo "listen_addresses='localhost'" >> /etc/postgresql/9.6/main/postgresql.conf \
-	&& rm -rf /var/lib/postgresql/9.6/main \
-	&& mkdir -p /var/lib/postgresql/9.6 \
-	&& chown -R postgres:postgres /var/lib/postgresql
+    && echo "host all all all md5" >> /etc/postgresql/12/main/pg_hba.conf \
+    && echo "listen_addresses='localhost'" >> /etc/postgresql/12/main/postgresql.conf \
+    && rm -rf /var/lib/postgresql/12/main \
+    && mkdir -p /var/lib/postgresql/12 \
+    && chown -R postgres:postgres /var/lib/postgresql
 
 # nginx
 ENV NGINX_HOST localhost

--- a/aio-base/docker-entrypoint.sh
+++ b/aio-base/docker-entrypoint.sh
@@ -84,12 +84,12 @@ prepare_app() {
 	# prepare config file and save it as app.properties
 	(
 		cd $CATALINA_BASE; \
-		[ ! -e application.properties -a -e webapps/ROOT.war ] \
-			&& jar xf webapps/ROOT.war WEB-INF/classes/application.properties \
-			&& mv WEB-INF/classes/application.properties . \
+		[ ! -e axelor-config.properties -a -e webapps/ROOT.war ] \
+			&& jar xf webapps/ROOT.war WEB-INF/classes/axelor-config.properties \
+			&& mv WEB-INF/classes/axelor-config.properties . \
 			&& rm -rf WEB-INF;
-		[ ! -e app.properties -a -e application.properties ] \
-			&& cp application.properties app.properties \
+		[ ! -e app.properties -a -e axelor-config.properties ] \
+			&& cp axelor-config.properties app.properties \
 			&& echo >> app.properties \
 			&& echo "application.mode = prod" >> app.properties \
 			&& echo "db.default.url = jdbc:postgresql://localhost:5432/$POSTGRES_DB" >> app.properties \

--- a/aio-base/nginx-ssl.conf
+++ b/aio-base/nginx-ssl.conf
@@ -47,7 +47,7 @@ server {
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Host $http_host;
+		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Server $host;
 		proxy_set_header X-Forwarded-Proto https;
 

--- a/aio-base/nginx.conf
+++ b/aio-base/nginx.conf
@@ -23,13 +23,13 @@ server {
 	root /var/lib/tomcat/webapps/static;
 
 	location @proxy {
-		proxy_http_version 1.1;
+	    proxy_http_version 1.1;
 		proxy_buffering off;
-		proxy_set_header Host $http_host;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Host $http_host;
-		proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
 
 		proxy_pass http://tomcat;
 		proxy_redirect off;


### PR DESCRIPTION
**Why?**
Make aio-base docker image compatible with axelor v7.

**How?**
Upgrade to jdk12, tomcat 9, postgres 12 and nginx 1.23.4

**How to test?**

- build image from aio-base folder: `docker build -t axelor/aio-base:v7 .`
- download axelor war from [github release](https://github.com/axelor/open-suite-webapp/releases).
- start container: `docker run -p 8080:80  -d -v <path-to-axelor-war-folder>/axelor-erp-v7.0.0.war:/var/lib/tomcat/webapps/ROOT.war axelor/aio-base:v7`